### PR TITLE
feat: 질문 페이지 헤더 컴포넌트 구현 및 접근성 개선 (#4)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,12 @@
+// components
+import QuestionHeader from "@/components/question/QuestionHeader"
+// constants
+import { TEST_USER } from "@/constants/test_user"
+
 export default function Home() {
-  return <main></main>
+  return (
+    <main>
+      <QuestionHeader defaultUser={TEST_USER} />
+    </main>
+  )
 }

--- a/src/components/question/QuestionHeader.test.tsx
+++ b/src/components/question/QuestionHeader.test.tsx
@@ -1,0 +1,105 @@
+import { useRouter } from "next/navigation"
+import "@testing-library/jest-dom"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+// components
+import QuestionHeader from "@/components/question/QuestionHeader"
+// constants
+import { TEST_USER } from "@/constants/test_user"
+import { PATHS } from "@/constants/paths"
+import { TIME_RANGES } from "@/constants/greetings"
+
+// Mocks
+jest.mock("next/navigation", () => ({
+  useRouter: jest.fn(),
+}))
+
+jest.mock("next/link", () => {
+  const MockLink = ({ children, href }: { children: React.ReactNode; href: string }) => {
+    const router = useRouter()
+    return (
+      <a
+        href={href}
+        onClick={(e) => {
+          e.preventDefault()
+          router.push(href)
+        }}
+      >
+        {children}
+      </a>
+    )
+  }
+
+  MockLink.displayName = "MockLink"
+  return MockLink
+})
+
+describe("QuestionHeader 컴포넌트", () => {
+  const mockPush = jest.fn()
+
+  const renderHeader = () => {
+    return render(<QuestionHeader defaultUser={TEST_USER} />)
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(useRouter as jest.Mock).mockReturnValue({ push: mockPush })
+  })
+
+  describe("기본 렌더링", () => {
+    beforeEach(() => {
+      renderHeader()
+    })
+
+    it("헤더 컴포넌트가 렌더링되어야 한다", () => {
+      expect(screen.getByRole("banner")).toBeInTheDocument()
+    })
+
+    it("기본 인사말이 표시되어야 한다", () => {
+      expect(screen.getByText(/Hi/)).toBeInTheDocument()
+    })
+
+    it("사용자의 닉네임이 표시되어야 한다", () => {
+      expect(screen.getByText(TEST_USER.nickname)).toBeInTheDocument()
+    })
+
+    it("프로필 이미지가 올바른 속성으로 표시되어야 한다", () => {
+      const element = screen.getByRole("img", {
+        name: new RegExp(`${TEST_USER.nickname} profile`, "i"),
+      })
+
+      expect(element).toBeInTheDocument()
+      expect(element).toHaveAttribute("src", TEST_USER.profileImage)
+    })
+  })
+
+  describe("페이지 이동", () => {
+    beforeEach(() => {
+      renderHeader()
+    })
+
+    it("프로필 링크가 올바른 경로를 가져야 한다", () => {
+      const element = screen.getByRole("link")
+      expect(element).toHaveAttribute("href", PATHS.PROFILE)
+    })
+
+    it("프로필 링크 클릭시 프로필 페이지로 이동해야 한다", async () => {
+      const user = userEvent.setup()
+      const element = screen.getByRole("link")
+
+      await user.click(element)
+      expect(mockPush).toHaveBeenCalledWith(PATHS.PROFILE)
+    })
+  })
+
+  describe("시간대별 인사말", () => {
+    it.each(TIME_RANGES.map(({ start, end, greeting }) => [start, end, greeting]))(
+      '%d시부터 %d시까지는 "%s" 메시지가 표시되어야 한다',
+      (start, end, greeting) => {
+        jest.spyOn(Date.prototype, "getHours").mockReturnValue(start)
+        renderHeader()
+        expect(screen.getByText(greeting)).toBeInTheDocument()
+      }
+    )
+  })
+})

--- a/src/components/question/QuestionHeader.tsx
+++ b/src/components/question/QuestionHeader.tsx
@@ -1,0 +1,40 @@
+import Link from "next/link"
+// types
+import { DefaultUser } from "@/types/user"
+// libs
+import { getTimeBasedGreeting } from "@/lib/getTimeBasedGreeting"
+// constants
+import { PATHS } from "@/constants/paths"
+
+interface QuestionHeaderProps {
+  defaultUser: DefaultUser
+}
+
+/**
+ * 질문 페이지 헤더
+ */
+export default function QuestionHeader({ defaultUser }: QuestionHeaderProps) {
+  return (
+    <header role="banner" className="flex justify-between items-center h-20 px-5">
+      <section className="flex flex-col">
+        <div className="text-xs">
+          <span className="mr-1">Hi!</span>
+          <span>{defaultUser.nickname}</span>
+        </div>
+        <p className="text-lg font-medium">{getTimeBasedGreeting()}</p>
+      </section>
+
+      <Link
+        className="w-12 h-12 rounded-full overflow-hidden"
+        aria-label={`${defaultUser.nickname}의 프로필로 이동`}
+        href={PATHS.PROFILE}
+      >
+        <img
+          className="w-full h-full object-cover"
+          src={defaultUser.profileImage}
+          alt={`${defaultUser.nickname} profile`}
+        />
+      </Link>
+    </header>
+  )
+}

--- a/src/constants/greetings.ts
+++ b/src/constants/greetings.ts
@@ -1,0 +1,15 @@
+export const TIME_BASED_GREETINGS = {
+  MORNING: "Good Morning!",
+  AFTERNOON: "Good Afternoon!",
+  EVENING: "Good Evening!",
+  NIGHT: "Good Night!",
+  INVALID: "Welcome!",
+} as const
+
+export const TIME_RANGES = [
+  { start: 0, end: 5, greeting: TIME_BASED_GREETINGS.EVENING },
+  { start: 5, end: 12, greeting: TIME_BASED_GREETINGS.MORNING },
+  { start: 12, end: 17, greeting: TIME_BASED_GREETINGS.AFTERNOON },
+  { start: 17, end: 21, greeting: TIME_BASED_GREETINGS.EVENING },
+  { start: 21, end: 24, greeting: TIME_BASED_GREETINGS.NIGHT },
+] as const

--- a/src/constants/paths.ts
+++ b/src/constants/paths.ts
@@ -1,0 +1,3 @@
+export const PATHS = {
+  PROFILE: "/profile",
+}

--- a/src/constants/test_user.ts
+++ b/src/constants/test_user.ts
@@ -1,0 +1,4 @@
+export const TEST_USER = {
+  profileImage: "https://i.pinimg.com/236x/24/a5/ee/24a5eeb64f5e14327850731fc8f01bd9.jpg",
+  nickname: "홍길동",
+} as const

--- a/src/lib/getTimeBasedGreeting.test.ts
+++ b/src/lib/getTimeBasedGreeting.test.ts
@@ -1,0 +1,82 @@
+// constants
+import { TIME_BASED_GREETINGS, TIME_RANGES } from "@/constants/greetings"
+// lib
+import { getGreetingForHour, getTimeBasedGreeting } from "@/lib/getTimeBasedGreeting"
+
+describe("인사말 관련 함수 테스트", () => {
+  describe("getGreetingForHour (시간별 인사말 반환 함수)", () => {
+    it.each([
+      { hours: 3, expected: TIME_BASED_GREETINGS.EVENING, description: "새벽 3시" },
+      { hours: 7, expected: TIME_BASED_GREETINGS.MORNING, description: "아침 7시" },
+      { hours: 14, expected: TIME_BASED_GREETINGS.AFTERNOON, description: "오후 2시" },
+      { hours: 19, expected: TIME_BASED_GREETINGS.EVENING, description: "저녁 7시" },
+      { hours: 22, expected: TIME_BASED_GREETINGS.NIGHT, description: "밤 10시" },
+    ])("$description에는 $expected 인사말을 반환해야 한다", ({ hours, expected }) => {
+      expect(getGreetingForHour(hours)).toBe(expected)
+    })
+
+    it("유효하지 않은 시간에는 기본 인사말을 반환해야 한다", () => {
+      expect(getGreetingForHour(24)).toBe(TIME_BASED_GREETINGS.INVALID)
+      expect(getGreetingForHour(25)).toBe(TIME_BASED_GREETINGS.INVALID)
+
+      // 소수점 시간 (선택적)
+      expect(getGreetingForHour(13.5)).toBe(TIME_BASED_GREETINGS.AFTERNOON)
+    })
+  })
+
+  describe("getTimeBasedGreeting (현재 시간 기준 인사말 반환 함수)", () => {
+    const mockDate = (hours: number) => {
+      const mockDate = new Date(2024, 0, 1, hours, 0, 0)
+      jest
+        .spyOn(global, "Date")
+        .mockImplementation(() => mockDate)
+        .mockImplementationOnce(() => mockDate)
+    }
+
+    beforeEach(() => {
+      jest.clearAllMocks()
+    })
+
+    afterEach(() => {
+      jest.restoreAllMocks()
+    })
+
+    it.each(TIME_RANGES)(
+      "$start시부터 $end시 사이에는 $greeting을 반환해야 한다",
+      ({ start, end, greeting }) => {
+        mockDate(start)
+        expect(getTimeBasedGreeting()).toBe(greeting)
+
+        if (end > start) {
+          mockDate(end - 1)
+          expect(getTimeBasedGreeting()).toBe(greeting)
+        }
+      }
+    )
+
+    // 시간대 경계값 테스트
+    it.each([
+      { hours: 5, expected: TIME_BASED_GREETINGS.MORNING, description: "아침 시작" },
+      { hours: 12, expected: TIME_BASED_GREETINGS.AFTERNOON, description: "오후 시작" },
+      { hours: 17, expected: TIME_BASED_GREETINGS.EVENING, description: "저녁 시작" },
+      { hours: 21, expected: TIME_BASED_GREETINGS.NIGHT, description: "밤 시작" },
+    ])("$description 시점에 정확한 인사말로 전환되어야 한다", ({ hours, expected }) => {
+      mockDate(hours)
+      expect(getTimeBasedGreeting()).toBe(expected)
+    })
+  })
+
+  describe("예외 상황 처리", () => {
+    it("시간대 범위의 경계값이 정상적으로 처리되어야 한다", () => {
+      TIME_RANGES.forEach(({ start, end, greeting }) => {
+        // 시작 시간 테스트
+        expect(getGreetingForHour(start)).toBe(greeting)
+
+        // 끝 시간 직전 테스트
+        if (end) {
+          expect(getGreetingForHour(end - 1)).toBe(greeting)
+        }
+      })
+    })
+  })
+})

--- a/src/lib/getTimeBasedGreeting.ts
+++ b/src/lib/getTimeBasedGreeting.ts
@@ -1,0 +1,18 @@
+// constants
+import { TIME_BASED_GREETINGS, TIME_RANGES } from "@/constants/greetings"
+
+type Greeting = (typeof TIME_BASED_GREETINGS)[keyof typeof TIME_BASED_GREETINGS]
+
+export const getGreetingForHour = (hours: number): Greeting => {
+  const range = TIME_RANGES.find(({ start, end }) => hours >= start && hours < end)
+  return range ? range.greeting : TIME_BASED_GREETINGS.INVALID
+}
+
+export function getTimeBasedGreeting(): Greeting {
+  const localTime = new Date().toLocaleString("en-US", {
+    timeZone: "Asia/Seoul",
+  })
+
+  const hours = new Date(localTime).getHours()
+  return getGreetingForHour(hours)
+}

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,0 +1,4 @@
+export interface DefaultUser {
+  profileImage: string
+  nickname: string
+}


### PR DESCRIPTION
* docs: 질문 페이지 헤더 컴포넌트 요구사항 작성

* test: 질문 페이지 헤더 컴포넌트 초기 테스트 설정

* feat: 질문 페이지 헤더 컴포넌트 기본 구조 구현

* test: 질문 페이지 헤더 컴포넌트 기능별 테스트 케이스 추가
- 인사말, 사용자 닉네임, 프로필 이미지 및 링크 클릭 기능 테스트
- 시간대별 인사말 표시 로직 테스트

* feat: 질문 페이지 헤더 컴포넌트 기본 기능 구현
- 사용자 인사말 및 닉네임 표시 추가
- 프로필 이미지 및 링크 클릭 시 페이지 이동 기능 구현
- 시간대에 따른 인사말 표시 로직 추가

* refactor: 질문 페이지 헤더 컴포넌트와 테스트 코드 리팩토링 및 구조 정리

* refactor: 상수 및 시간대별 인사말 로직 리팩토링
- 애플리케이션 경로를 상수로 정의하기 위해 `paths.ts` 추가
- 시간대별 인사말 관리를 위한 `greetings.ts` 생성
- 가독성과 유지보수성을 개선하기 위해 `getTimeBasedGreeting` 및 `getGreetingForHour` 함수 리팩토링
- 새로운 인사말 상수를 활용하도록 헤더 컴포넌트 업데이트
- 시간에 따라 올바른 인사말이 표시되는지 확인하기 위해 헤더 테스트 조정

* feat: 시간대별 인사말에 유효하지 않은 경우 처리 추가

- greeting 상수에 INVALID: "Welcome!" 추가
- getTimeBasedGreeting 함수에서 일치하는 시간대가 없을 경우 INVALID 인사말 반환하도록 수정

* test: getTimeBasedGreeting 함수에 대한 테스트 코드 작성

* style: 헤더 컴포넌트 스타일링 및 시맨틱 구조 개선

* chore: 테스트 유저 프로필 이미지 변경

* feat: 접근성을 위해 QuestionHeader 컴포넌트에 aria-label 추가