### PR TITLE
feat: 회원가입 시 API 토큰과 사용자 정보를 AuthContext에 저장

### DIFF
--- a/app/api/auth/signup/route.ts
+++ b/app/api/auth/signup/route.ts
@@ -31,6 +31,10 @@ export async function POST(request: Request) {
       data: {
         accessToken: tokens.accessToken,
         refreshToken: tokens.refreshToken,
+        user: {
+          id: TEST_USER_ID,
+          email,
+        },
       },
     })
   } catch (error) {

--- a/src/entities/user/mocks/user.ts
+++ b/src/entities/user/mocks/user.ts
@@ -1,4 +1,7 @@
 export const MOCK_USER = {
-  profileImage: "https://i.pinimg.com/236x/24/a5/ee/24a5eeb64f5e14327850731fc8f01bd9.jpg",
+  id: 1234,
+  email: "example@example.com",
   nickname: "홍길동",
+  profileImage:
+    "https://i.pinimg.com/236x/24/a5/ee/24a5eeb64f5e14327850731fc8f01bd9.jpg",
 } as const

--- a/src/entities/user/types/user.ts
+++ b/src/entities/user/types/user.ts
@@ -1,5 +1,6 @@
 export interface User {
   id: number
-  profileImage: string
+  email: string
   nickname: string
+  profileImage: string
 }

--- a/src/features/auth/actions/auth.tsx
+++ b/src/features/auth/actions/auth.tsx
@@ -3,12 +3,20 @@
 import { revalidatePath } from "next/cache"
 import { cookies } from "next/headers"
 import jwt, { JwtPayload } from "jsonwebtoken"
+// lib
+import { getEnv } from "@/shared/lib"
 
 interface AuthResponse {
   message: string
   data: {
     accessToken: string
     refreshToken: string
+    user: {
+      id: number
+      email: string
+      nickname: string
+      profileImage: string
+    }
   }
 }
 
@@ -28,7 +36,7 @@ export async function signup(formData: FormData) {
     }
 
     const response = await fetch(
-      `${process.env.NEXT_PUBLIC_BASE_URL}/api/auth/signup`,
+      `${getEnv("NEXT_PUBLIC_BASE_URL")}/api/auth/signup`,
       {
         method: "POST",
         headers: {
@@ -46,7 +54,7 @@ export async function signup(formData: FormData) {
     }
 
     const body: AuthResponse = await response.json()
-    const { accessToken, refreshToken } = body.data
+    const { user, accessToken, refreshToken } = body.data
 
     // 페이지 데이터 갱신
     revalidatePath("/signup")
@@ -58,6 +66,7 @@ export async function signup(formData: FormData) {
     return {
       success: true,
       accessToken,
+      user,
     }
   } catch (error) {
     console.error("Signup error:", error)

--- a/src/features/auth/components/SignupForm.tsx
+++ b/src/features/auth/components/SignupForm.tsx
@@ -27,14 +27,17 @@ function SubmitButton() {
   )
 }
 
+/**
+ * 회원가입 페이지
+ */
 export function SignupForm() {
+  const router = useRouter()
+  const { setUser, setAccessToken } = useAuth()
+
   const [error, setError] = useState<string | null>(null)
   const [success, setSuccess] = useState(false)
   const [, startTransition] = useTransition()
   const { errors, validateField } = useValidation()
-  const router = useRouter()
-
-  const { setAccessToken } = useAuth()
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
@@ -53,14 +56,14 @@ export function SignupForm() {
     try {
       startTransition(async () => {
         const result = await signup(formData)
-        if (result.accessToken) {
-          setAccessToken(result.accessToken)
-        }
-
+        const { user, accessToken } = result
+        // 응답에서 사용자 정보와 액세스 토큰을 받아 AuthContext에 저장한다.
+        setUser(user)
+        setAccessToken(accessToken)
         setSuccess(true)
 
         form.reset()
-        router.replace("/login")
+        router.replace("/")
       })
     } catch (e) {
       setError(

--- a/src/shared/context/AuthContext.tsx
+++ b/src/shared/context/AuthContext.tsx
@@ -3,6 +3,8 @@
 import { createContext, ReactNode, useContext, useState } from "react"
 
 interface AuthContextType {
+  user: { id: number; email: string } | null
+  setUser: (user: { id: number; email: string } | null) => void
   accessToken: string | null
   setAccessToken: (token: string | null) => void
 }
@@ -10,10 +12,18 @@ interface AuthContextType {
 const AuthContext = createContext<AuthContextType | null>(null)
 
 export function AuthProvider({ children }: Readonly<{ children: ReactNode }>) {
+  const [user, setUser] = useState<{ id: number; email: string } | null>(null)
   const [accessToken, setAccessToken] = useState<string | null>(null)
 
   return (
-    <AuthContext.Provider value={{ accessToken, setAccessToken }}>
+    <AuthContext.Provider
+      value={{
+        user,
+        setUser,
+        accessToken,
+        setAccessToken,
+      }}
+    >
       {children}
     </AuthContext.Provider>
   )


### PR DESCRIPTION
- API 응답에서 반환된 사용자 정보와 토큰을 AuthContext 상태에 저장하도록 회원가입 로직 수정
- 사용자 상태와 액세스 토큰 관리 추가
- 사용자 정보 리턴 값에 email과 nickname, profileImage을 추가
- User 타입에 email과 nickname, profileImage 필드 추가